### PR TITLE
Improve merger.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Modules/compiled/

--- a/Modules/merger.py
+++ b/Modules/merger.py
@@ -4,6 +4,7 @@
 import subprocess as sbp
 import os
 import shutil
+import sys
 import time
 
 from distutils.dir_util import copy_tree
@@ -13,6 +14,12 @@ modules = ["appstore", "bootlogo", "edizon", "goldleaf",
         "sys-ftpd", "sys-netcheat", "kosmos_toolkit", "emuiibo",
         "lockpick", "hid-mitm", "sys-clk", "ldn_mitm"] # Everything that will be merged together
 output_dir = "compiled" # How the merged folder should be called
+
+if len(sys.argv) != 2:
+    print("usage: merger.py <kosmos_version>")
+    exit()
+
+version = sys.argv[1]
 
 print("""
                         https://github.com/AtlasNX/Kosmos
@@ -40,5 +47,15 @@ working_dir = os.path.dirname(os.path.realpath(__file__))
 for path in modules:
     path = os.path.join(working_dir, path)
     copy_tree(path, output_dir)
+
+# Check every file in the output directory for the {$KOSMOS_VERSION} token and replace it with
+# the supplied Kosmos version.
+for directory, subdirectories, files in os.walk(output_dir):
+    for file in files:
+        contents = open(os.path.join(directory, file)).read()
+        contents = contents.replace("{$KOSMOS_VERSION}", version)
+        handle = open(os.path.join(directory, file), "w")
+        handle.write(contents)
+        handle.close()
 
 print("Done!")

--- a/Modules/merger.py
+++ b/Modules/merger.py
@@ -12,7 +12,7 @@ modules = ["appstore", "bootlogo", "edizon", "goldleaf",
         "hbmenu", "hekate_payload", "must_have", "kosmosupdater", 
         "sys-ftpd", "sys-netcheat", "kosmos_toolkit", "emuiibo",
         "lockpick", "hid-mitm", "sys-clk", "ldn_mitm"] # Everything that will be merged together
-p2 = "compiled" # How the merged folder should be called
+output_dir = "compiled" # How the merged folder should be called
 
 print("""
                         https://github.com/AtlasNX/Kosmos
@@ -30,15 +30,15 @@ print("""
 It could be that a permissions error will pop up, fix it by restarting the python script! We don\'t really know why that happens!
 """) # Fancy stuff
 
-if os.path.exists("compiled"):
-    shutil.rmtree("compiled") # Delete Content of "compiled" if it exists!
+if os.path.exists(output_dir):
+    shutil.rmtree(output_dir) # Delete Content of "compiled" if it exists!
 
-os.makedirs("compiled") # Double check
+os.makedirs(output_dir) # Double check
 
 # Copy modules to "compiled" directory
 working_dir = os.path.dirname(os.path.realpath(__file__))
 for path in modules:
     path = os.path.join(working_dir, path)
-    copy_tree(path, "compiled")
+    copy_tree(path, output_dir)
 
 print("Done!")

--- a/Modules/merger.py
+++ b/Modules/merger.py
@@ -6,6 +6,8 @@ import os
 import shutil
 import time
 
+from distutils.dir_util import copy_tree
+
 modules = ["appstore", "bootlogo", "edizon", "goldleaf", 
         "hbmenu", "hekate_payload", "must_have", "kosmosupdater", 
         "sys-ftpd", "sys-netcheat", "kosmos_toolkit", "emuiibo",
@@ -33,12 +35,10 @@ if os.path.exists("compiled"):
 
 os.makedirs("compiled") # Double check
 
+# Copy modules to "compiled" directory
+working_dir = os.path.dirname(os.path.realpath(__file__))
 for path in modules:
-    fol = os.listdir(path)
-    for i in fol:
-        p1 = os.path.join(path,i)
-        p3 = 'cp -r ' + p1 +' ' + p2+'/.'
-        sbp.Popen(p3,shell=True)
-        time.sleep(0.1)
+    path = os.path.join(working_dir, path)
+    copy_tree(path, "compiled")
 
 print("Done!")

--- a/Modules/must_have/bootloader/hekate_ipl.ini
+++ b/Modules/must_have/bootloader/hekate_ipl.ini
@@ -8,7 +8,7 @@ backlight=100
 autohosoff=0
 autonogc=1
 
-{AtlasNX/Kosmos v12.1.1}
+{AtlasNX/Kosmos {$KOSMOS_VERSION}}
 { }
 {Discord: discord.teamatlasnx.com}
 {Github: git.teamatlasnx.com}


### PR DESCRIPTION
* Actually use the output directory variable that was present but not used
* Replace shell commands with standard library methods, adding Windows support and removing the wait time
* Require the version number be passed in as a command-line argument, and replace the token `{$KOSMOS_VERSION}` in all files within the output directory with the supplied version number.